### PR TITLE
Handle post-upgrade check on uptime

### DIFF
--- a/device-healthcheck-action-pack/device-healthcheck/script.py
+++ b/device-healthcheck-action-pack/device-healthcheck/script.py
@@ -236,11 +236,16 @@ def verify_syslog(device):
 # Report uptime below 24 hours.
 def verify_uptime(device):
     try:
-        response = device.runDeviceCmds(['show uptime'])
+        response = device.runCmds(['show uptime'])
         if response[0]['response']['upTime'] > 86400:
             return True
         else:
-            return False
+            # If we reloaded in the last 24 hours, at a user request
+            # Then this test case should pass (cover reload due to upgrade)
+            if verify_reload_cause(device) is not True:
+                return False
+            else:
+                return True
     except:
         return None
 

--- a/device-healthcheck/cvp-device-health-check.py
+++ b/device-healthcheck/cvp-device-health-check.py
@@ -257,7 +257,12 @@ def verify_uptime(device):
         if response[0]['response']['upTime'] > 86400:
             return True
         else:
-            return False
+            # If we reloaded in the last 24 hours, at a user request
+            # Then this test case should pass (cover reload due to upgrade)
+            if verify_reload_cause(device) is not True:
+                return False
+            else:
+                return True
     except:
         return None
 


### PR DESCRIPTION
If a health check was done, for example, after an upgrade, the health check would fail.

This enhancement allows the uptime test case to pass, if the reload was triggered manually