### PR TITLE
Check spine prefixes

### DIFF
--- a/device-healthcheck/cvp-device-health-check.py
+++ b/device-healthcheck/cvp-device-health-check.py
@@ -15,7 +15,6 @@ CVP_SESSION_ID - Session id of current cvp user, this can be passed around to cv
 SCRIPT_ARGS - A dictionary of arguments passed to the Script Action
 """
 
-from zmq import PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_MESSAGE
 from cvplibrary import CVPGlobalVariables, GlobalVariableNames
 from cvplibrary import RestClient
 from cvplibrary import Device


### PR DESCRIPTION
Add a test to do the following;

1. Identify the  spine facing ports (SPINE_HINT)
2. Collect the local interface IPs for the spine ports
3. Calculate the peer address for the spine ports
4. Get the # of accepted prefixes from each spine
5. Check that they are all the same