### PR TITLE
Lab testing

### DIFF
--- a/device-healthcheck/cvp-device-health-check.py
+++ b/device-healthcheck/cvp-device-health-check.py
@@ -790,6 +790,9 @@ def verify_bgp_spine_prefixes(device):
             if SCRIPT_DEBUG:
                 alog("No routed interfaces found: %s" % routed_interfaces)
             return None
+        if len(peers['vrfs']) == 0:
+            alog("BGP not running - skipping check")
+            return None
         if len(peers['vrfs'][UNDERLAY_VRF]['peers']) == 0:
             if SCRIPT_DEBUG:
                 alog("No BGP peers found in default VRF: %s" % peers)

--- a/device-healthcheck/cvp-device-health-check.py
+++ b/device-healthcheck/cvp-device-health-check.py
@@ -595,8 +595,8 @@ def verify_mlag_interfaces(device):
         response = device.runCmds(['show mlag'])
         if response[0]['response']['state'] == 'disabled':
             return None
-        elif response[0]['response']['mlagPorts']['Inactive'] != 0:
-            return False
+#        elif response[0]['response']['mlagPorts']['Inactive'] != 0:
+#            return False
         elif response[0]['response']['mlagPorts']['Active-partial'] != 0:
             return False
         else:

--- a/device-healthcheck/cvp-device-health-check.py
+++ b/device-healthcheck/cvp-device-health-check.py
@@ -274,7 +274,8 @@ def verify_uptime(device):
 def verify_reload_cause(device):
     try:
         response = device.runCmds(['show reload cause'])
-        if response[0]['response']['resetCauses'][0]['description'] == 'Reload requested by the user.':
+        if response[0]['response']['resetCauses'][0]['description'] == 'Reload requested by the user.' or \
+           response[0]['response']['resetCauses'][0]['description'] == 'Reload requested after FPGA upgrade.':
             return True
         else:
             return False

--- a/device-healthcheck/cvp-device-health-check.py
+++ b/device-healthcheck/cvp-device-health-check.py
@@ -478,7 +478,8 @@ def verify_portchannels(device):
             return None
         else:
             for portchannel in response[0]['response']['portChannels']:
-                if len(response[0]['response']['portChannels'][portchannel]['inactivePorts']) != 0:
+                if len(response[0]['response']['portChannels'][portchannel]['inactivePorts']) != 0 and \
+                    len(response[0]['response']['portChannels'][portchannel]['activePorts']) > 0:
                     return False
             return True
     except:

--- a/device-healthcheck/cvp-device-health-check.py
+++ b/device-healthcheck/cvp-device-health-check.py
@@ -275,7 +275,7 @@ def verify_reload_cause(device):
     try:
         response = device.runCmds(['show reload cause'])
         if response[0]['response']['resetCauses'][0]['description'] == 'Reload requested by the user.' or \
-           response[0]['response']['resetCauses'][0]['description'] == 'Reload requested after FPGA upgrade.':
+           response[0]['response']['resetCauses'][0]['description'] == 'Reload requested after FPGA upgrade':
             return True
         else:
             return False


### PR DESCRIPTION
Updated based on lab testing - relaxing/tweaking the following tests.

- verify_reload_cause - allow for an extra reload if the FPGA is upgraded
- verify_portchannels - allow for a port-channel to be completely down/inactive e.g. in LACP fallback
- verify_mlag_interfaces - allow MLAG inactive ports
- verify_bgp_spine_prefixes - skip check if BGP isn't running