### PR TITLE
Update cvp-device-health-check.py

### DIFF
--- a/device-healthcheck/cvp-device-health-check.py
+++ b/device-healthcheck/cvp-device-health-check.py
@@ -271,8 +271,16 @@ def verify_uptime(device):
 def verify_reload_cause(device):
     try:
         response = device.runCmds(['show reload cause'])
-        if response[0]['response']['resetCauses'][0]['description'] == 'Reload requested by the user.':
+        if response[0]['response']['resetCauses'][0]['description'] == 'Reload requested by the user.' or \
+           response[0]['response']['resetCauses'][0]['description'] == 'Reload requested after FPGA upgrade':
             return True
+        elif response[0]['response']['resetCauses'][0]['description'] == 'The system rebooted due to a Power Loss':
+            uptime = device.runCmds(['show uptime'])
+            if uptime[0]['response']['upTime'] >= 86400:
+                return True
+            else:
+                return False
+            
         else:
             return False
     except:


### PR DESCRIPTION
Adjust for reload causes. Take uptime into account if the switch suffered power loss